### PR TITLE
added features to ignore and replace urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This plugin archives links in your note so they're available to you even if the 
 Upon pressing the "Archive Links" button in the ribbon/left sidebar, the plugin:
 
 1. looks up every external link in the current note,
-2. sumbits each of them to https://archive.org,
+2. submits each of them to https://archive.org,
 3. as soon as they are saved, it embeds an `(Archived)` link after the regular link in your note.
 
 The plugin will attempt not to recreate archive links for already-archived links (and the archive links themselves) - but this relies on not modifying the formatting of the archive links.

--- a/settings.ts
+++ b/settings.ts
@@ -2,6 +2,11 @@ import { App, PluginSettingTab, Setting } from "obsidian";
 import ObsidianLinkArchivePlugin from "./main";
 import { defaultArchiveText } from "./constants";
 
+export interface LinkReplaceRule {
+    originalPattern: string;
+    replacementPattern: string;
+}
+
 export const enum ArchiveOptions {
 	Wayback,
 	Archiveis,
@@ -12,11 +17,15 @@ export const enum ArchiveOptions {
 export interface LinkArchivePluginSettings {
 	archiveOption: ArchiveOptions;
 	archiveText: string;
+	linkReplaceRules: LinkReplaceRule[];
+	ignoreUrlPatterns: string[];
 }
 
 export const defaultSettings: LinkArchivePluginSettings = {
 	archiveOption: ArchiveOptions.Archiveis,
-	archiveText: defaultArchiveText
+	archiveText: defaultArchiveText,
+	linkReplaceRules: [],
+	ignoreUrlPatterns: []
 }
 
 
@@ -30,54 +39,118 @@ export class LinkArchiveSettingTab extends PluginSettingTab {
 
 	display(): void {
 		const plugin: ObsidianLinkArchivePlugin = (this as any).plugin;
-
-        const { containerEl } = this;
+		const { containerEl } = this;
 
 		containerEl.empty();
 
 		// add archive link text customization option
+		const archiveSettingsSection = containerEl.createDiv();
+		archiveSettingsSection.createEl("h2", { text: "Archive Settings" });
 
-		containerEl.createEl("h2", {text: "Archive Settings"});
+		new Setting(archiveSettingsSection)
+		.setName("Link text")
+		.setDesc("The text of the archive links")
+		.addText(text =>
+				 text
+		.setValue(plugin.settings.archiveText)
+		.onChange(async value => {
+			console.log(`Link text: ${value}`);
+			plugin.settings.archiveText = value;
+			await plugin.saveSettings();
+		}));
 
-        new Setting(containerEl)
-            .setName("Link text")
-            .setDesc("The text of the archive links")
-            .addText(text =>
-                text
-                    .setValue(plugin.settings.archiveText)
-                    .onChange(async value => {
-                        console.log(`Link text: ${value}`);
-                        plugin.settings.archiveText = value;
-                        await plugin.saveSettings();
-                    }));
+		// link ignore rules
+		const linkIgnoreSection = containerEl.createDiv();
+		linkIgnoreSection.createEl("h2", { text: "Link Ignore Rules" });
 
-		// new Setting(containerEl)
-		// 	.setName('Archive Provider')
-		// 	.setDesc('Choose a provider for the link archive')
-		// 	.addDropdown((dropdown) => {
-		// 		const options: Record<ArchiveOptions, string> = {
-		// 			0: "Internet Archive",
-		// 			1: "archive.is",
-		// 			2: "Both"
-		// 		};
+		new Setting(linkIgnoreSection)
+		.setName("Ignore URL Patterns")
+		.setDesc("Enter regular expressions to match URLs that should be ignored by the plugin")
+		.addButton(button => {
+			button.setButtonText("Add Pattern").onClick(() => {
+				plugin.settings.ignoreUrlPatterns.push("");
+				this.display();
+			});
+		});
 
-		// 		dropdown
-		// 			.addOptions(options)
-		// 			.setValue(plugin.settings.archiveOption.toString())
-		// 			.onChange(async (value) => {
-		// 				console.log('Archive option: ' + value);
-		// 				plugin.settings.archiveOption = +value;
-		// 				await plugin.saveSettings();
-		// 				this.display();
-		// 		})
-		// 	});
+		// add ignore url patterns
+		for (let i = 0; i < plugin.settings.ignoreUrlPatterns.length; i++) {
+			const pattern = plugin.settings.ignoreUrlPatterns[i];
 
-		containerEl.createEl("h2", {text: "About Link Archive"});
+			const setting = new Setting(containerEl)
+			.setName(`Pattern ${i + 1}`)
+			.addText(text => text
+					 .setPlaceholder("URL Pattern")
+					 .setValue(pattern)
+					 .onChange(async value => {
+						 plugin.settings.ignoreUrlPatterns[i] = value;
+						 await plugin.saveSettings();
+					 }));
 
-		containerEl.createEl("p", {text: "This plugin archives links in your note so they're available to you even if the original site goes down or gets removed."});
+					 setting.addButton(button => {
+						 button.setIcon("cross")
+						 .onClick(async () => {
+							 plugin.settings.ignoreUrlPatterns.splice(i, 1);
+							 await plugin.saveSettings();
+							 this.display();
+						 });
+					 });
+		}
 
-		containerEl.createEl("a", {text: "Open GitHub repository", href: "https://github.com/tomzorz/obsidian-link-archive"});
+		// add link replacement rules
+		const linkReplacementSection = containerEl.createDiv();
+		linkReplacementSection.createEl("h2", { text: "Link Replacement Rules" });
 
-		// TODO github support and ko-fi
+		new Setting(linkReplacementSection)
+		.setDesc("Configure rules to replace specific links before archiving.")
+		.addButton(button => {
+			button.setButtonText("Add Rule").onClick(() => {
+				plugin.settings.linkReplaceRules.push({
+					originalPattern: "",
+					replacementPattern: ""
+				});
+				this.display();
+			});
+		});
+
+		// add link replacement rules
+		for (let i = 0; i < plugin.settings.linkReplaceRules.length; i++) {
+			const rule = plugin.settings.linkReplaceRules[i];
+
+			const setting = new Setting(containerEl)
+			.setName(`Rule ${i + 1}`)
+			.addText(text => text
+					 .setPlaceholder("Original Pattern")
+					 .setValue(rule.originalPattern)
+					 .onChange(async value => {
+						 rule.originalPattern = value;
+						 await plugin.saveSettings();
+					 }))
+					 .addText(text => text
+							  .setPlaceholder("Replacement Pattern")
+							  .setValue(rule.replacementPattern)
+							  .onChange(async value => {
+								  rule.replacementPattern = value;
+								  await plugin.saveSettings();
+							  }));
+
+							  setting.addButton(button => {
+								  button.setIcon("cross")
+								  .onClick(async () => {
+									  plugin.settings.linkReplaceRules.splice(i, 1);
+									  await plugin.saveSettings();
+									  this.display();
+								  });
+							  });
+		}
+
+		// add about section
+		const aboutSection = containerEl.createDiv();
+		aboutSection.createEl("h2", { text: "About Link Archive" });
+
+		aboutSection.createEl("p", {text: "This plugin archives links in your note so they're available to you even if the original site goes down or gets removed."});
+
+		aboutSection.createEl("a", {text: "Open GitHub repository", href: "https://github.com/tomzorz/obsidian-link-archive"});
+
 	}
 }


### PR DESCRIPTION
This merge requests adds the two features I've requested in #15.

Two major changes:
- Added features: ignore list, replacement patterns.
- Changed behavior for checking if a link is archived.

# Settings menu

It adds two new sections to the settings page.
The first one is used to add links to the ignore list. It's using regex to describe a url tho you need to escape dots in the urls. For example if you want to add youtube to the ignore list you can add `www\.youtube\.com`. This matches all links containing the string because no `$` or `^` is used.

The second one is used to create replacements. There is one box where you can add the pattern for the original pattern and one for the replacement. Within the original pattern you need to escape dots and in the replacement pattern you don't. You can use groups like this: original is `http:\/\/(.+)` and replacement `https://$1`.

![image](https://github.com/tomzorz/obsidian-link-archive/assets/13796963/e1800174-be5c-4901-9dbc-6add025b0d2b)

# Changed behavior for checking if a link is archived

I've added three rules for checking if a link is already archived to the filter.

Two of them are the trivial ones: all links in the ignore list are filtered and all links where a replaced link is in the list is ignored.

The third one is not really related to the issue, but I thought it would be nice to have. If you don't like it i would remove it or add an option in the settings menu for it.

The third one checks if the link is followed by ` [Archived]` (the same format as the plugin adds it to the note). This is useful to add a custom archived link.